### PR TITLE
Bug non responding server

### DIFF
--- a/jtrust-lib/src/main/java/be/fedict/trust/ServerNotAvailableException.java
+++ b/jtrust-lib/src/main/java/be/fedict/trust/ServerNotAvailableException.java
@@ -56,7 +56,7 @@ public class ServerNotAvailableException extends Exception {
 	 * @param cause
 	 *            the cause
 	 */
-	public ServerNotAvailableException(final String message, final ServerType serverType, Throwable cause) {
+	public ServerNotAvailableException(final String message, final ServerType serverType, final Throwable cause) {
 		super(message, cause);
 		this.serverType = serverType;
 	}

--- a/jtrust-lib/src/main/java/be/fedict/trust/ServerNotAvailableException.java
+++ b/jtrust-lib/src/main/java/be/fedict/trust/ServerNotAvailableException.java
@@ -47,6 +47,21 @@ public class ServerNotAvailableException extends Exception {
     }
 
 	/**
+	 * Creates a new {@link ServerNotAvailableException}.
+	 *
+	 * @param message
+	 * 			  the error message
+	 * @param serverType
+	 *            the {@link ServerType} that this exception pertains to
+	 * @param cause
+	 *            the cause
+	 */
+	public ServerNotAvailableException(final String message, final ServerType serverType, Throwable cause) {
+		super(message, cause);
+		this.serverType = serverType;
+	}
+
+	/**
 	 * Returns the {@link ServerType} that this exception pertains to.
 	 * 
 	 * @return the serverType the {@link ServerType} that this exception pertains to

--- a/jtrust-lib/src/main/java/be/fedict/trust/crl/OnlineCrlRepository.java
+++ b/jtrust-lib/src/main/java/be/fedict/trust/crl/OnlineCrlRepository.java
@@ -21,7 +21,6 @@ package be.fedict.trust.crl;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.security.NoSuchProviderException;
@@ -118,16 +117,14 @@ public class OnlineCrlRepository implements CrlRepository {
 		final HttpGet httpGet = new HttpGet(downloadUrl);
 		httpGet.addHeader("User-Agent", "jTrust CRL Client");
 
-		// TODO: [BUG] Gooi een ServerNotAvailableException als de HttpClient#execute een ConnectionException gooit.
 		final HttpResponse httpResponse;
 		final int statusCode;
 		try {
 			httpResponse = httpClient.execute(httpGet);
 			final StatusLine statusLine = httpResponse.getStatusLine();
 			statusCode = statusLine.getStatusCode();
-		} catch (ConnectException e) {
-			// TODO: [REVIEW]
-			throw new ServerNotAvailableException("CRL server is down", ServerType.CRL);
+		} catch (IOException e) {
+			throw new ServerNotAvailableException("CRL server is down", ServerType.CRL, e);
 		}
 
 		if (HttpURLConnection.HTTP_OK != statusCode) {

--- a/jtrust-lib/src/main/java/be/fedict/trust/crl/OnlineCrlRepository.java
+++ b/jtrust-lib/src/main/java/be/fedict/trust/crl/OnlineCrlRepository.java
@@ -21,6 +21,7 @@ package be.fedict.trust.crl;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.security.NoSuchProviderException;
@@ -42,8 +43,6 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.bouncycastle.x509.NoSuchParserException;
-import org.bouncycastle.x509.util.StreamParsingException;
 
 import be.fedict.trust.Credentials;
 import be.fedict.trust.NetworkConfig;
@@ -95,15 +94,14 @@ public class OnlineCrlRepository implements CrlRepository {
 		} catch (final CRLException e) {
 			LOG.debug("error parsing CRL: " + e.getMessage(), e);
 			return null;
-		} catch (final IOException | CertificateException | NoSuchProviderException | NoSuchParserException | StreamParsingException e) {
+		} catch (final IOException | CertificateException | NoSuchProviderException e) {
 			LOG.error("find CRL error: " + e.getMessage(), e);
 			return null;
 		}
 	}
 
 	private X509CRL getCrl(final URI crlUri) throws IOException,
-			CertificateException, CRLException, NoSuchProviderException,
-			NoSuchParserException, StreamParsingException, ServerNotAvailableException {
+			CertificateException, CRLException, NoSuchProviderException, ServerNotAvailableException {
 		final DefaultHttpClient httpClient = new DefaultHttpClient();
 
 		if (null != this.networkConfig) {
@@ -120,9 +118,17 @@ public class OnlineCrlRepository implements CrlRepository {
 		final HttpGet httpGet = new HttpGet(downloadUrl);
 		httpGet.addHeader("User-Agent", "jTrust CRL Client");
 
-		final HttpResponse httpResponse = httpClient.execute(httpGet);
-		final StatusLine statusLine = httpResponse.getStatusLine();
-		final int statusCode = statusLine.getStatusCode();
+		// TODO: [BUG] Gooi een ServerNotAvailableException als de HttpClient#execute een ConnectionException gooit.
+		final HttpResponse httpResponse;
+		final int statusCode;
+		try {
+			httpResponse = httpClient.execute(httpGet);
+			final StatusLine statusLine = httpResponse.getStatusLine();
+			statusCode = statusLine.getStatusCode();
+		} catch (ConnectException e) {
+			// TODO: [REVIEW]
+			throw new ServerNotAvailableException("CRL server is down", ServerType.CRL);
+		}
 
 		if (HttpURLConnection.HTTP_OK != statusCode) {
 			throw new ServerNotAvailableException("CRL server responded with status code " + statusCode, ServerType.CRL);

--- a/jtrust-lib/src/main/java/be/fedict/trust/ocsp/OnlineOcspRepository.java
+++ b/jtrust-lib/src/main/java/be/fedict/trust/ocsp/OnlineOcspRepository.java
@@ -148,8 +148,7 @@ public class OnlineOcspRepository implements OcspRepository {
 			StatusLine statusLine = httpResponse.getStatusLine();
 			responseCode = statusLine.getStatusCode();
 		} catch (ConnectException e) {
-			// TODO: [REVIEW]
-			throw new ServerNotAvailableException("OCSP responder is down", ServerType.OCSP);
+			throw new ServerNotAvailableException("OCSP responder is down", ServerType.OCSP, e);
 		}
 
 		if (HttpURLConnection.HTTP_OK != responseCode) {

--- a/jtrust-lib/src/main/java/be/fedict/trust/ocsp/OnlineOcspRepository.java
+++ b/jtrust-lib/src/main/java/be/fedict/trust/ocsp/OnlineOcspRepository.java
@@ -147,7 +147,7 @@ public class OnlineOcspRepository implements OcspRepository {
 			httpResponse = httpClient.execute(httpPost);
 			StatusLine statusLine = httpResponse.getStatusLine();
 			responseCode = statusLine.getStatusCode();
-		} catch (ConnectException e) {
+		} catch (IOException e) {
 			throw new ServerNotAvailableException("OCSP responder is down", ServerType.OCSP, e);
 		}
 

--- a/jtrust-lib/src/main/java/be/fedict/trust/ocsp/OnlineOcspRepository.java
+++ b/jtrust-lib/src/main/java/be/fedict/trust/ocsp/OnlineOcspRepository.java
@@ -148,8 +148,8 @@ public class OnlineOcspRepository implements OcspRepository {
 			StatusLine statusLine = httpResponse.getStatusLine();
 			responseCode = statusLine.getStatusCode();
 		} catch (ConnectException e) {
-			LOG.debug("OCSP responder is down");
-			return null;
+			// TODO: [REVIEW]
+			throw new ServerNotAvailableException("OCSP responder is down", ServerType.OCSP);
 		}
 
 		if (HttpURLConnection.HTTP_OK != responseCode) {


### PR DESCRIPTION
**TFS #92199 OCSP unavailability on 5/2: check logs**

The classes OnlineCrlRepository and OnlineOcspRepository now catch the IOException thrown by a HttpClient#execute and throws a ServerNotAvailable exception with a message  that the server is down and the root cause.